### PR TITLE
Added skipping Epic ticket types

### DIFF
--- a/jira-stats-serverless/analyzer/csv_exporter.go
+++ b/jira-stats-serverless/analyzer/csv_exporter.go
@@ -24,14 +24,14 @@ func GetCsv(startDate time.Time, endDate time.Time) (*domain.CsvContents, error)
 	for _, ticket := range ticketsWithDevBefore {
 		rows = append(rows, domain.CsvRow{
 			Entries: []string{
-				ticket.Key, csvEscape(ticket.Title), ticket.Project(),
+				ticket.Key, ticket.Type, csvEscape(ticket.Title), ticket.Project(),
 				strconv.FormatFloat(domain.CalculateDevDays(ticket, startDate, endDate), 'f', 2, 64),
 			},
 		})
 	}
 
 	return &domain.CsvContents{
-		Header: []string{"Key", "Summary", "Project", "Dev Time (days)"},
+		Header: []string{"Key", "Type", "Summary", "Project", "Dev Time (days)"},
 		Rows:   rows,
 	}, nil
 }

--- a/jira-stats-serverless/analyzer/domain/dev_time_calculator.go
+++ b/jira-stats-serverless/analyzer/domain/dev_time_calculator.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"log"
 	"time"
 )
 
@@ -20,12 +21,21 @@ const StateDev = "In Development"
 func CalculateDevDays(ticket Ticket, start time.Time, end time.Time) float64 {
 	var cumulativeTime int
 
+	if shouldSkipTicket(ticket) {
+		log.Printf("Ticket %s has been skipped from dev time calculation", ticket.Key)
+		return 0.0
+	}
+
 	for _, transition := range ticket.Transitions {
 		devTime := calculateDevTime(transition, start, end)
 		cumulativeTime += devTime
 	}
 
 	return float64(cumulativeTime) / 8.0
+}
+
+func shouldSkipTicket(ticket Ticket) bool {
+	return ticket.Type == "Epic" // epics are being skipped from calculation
 }
 
 func calculateDevTime(interval TransitionInterval, start time.Time, end time.Time) int {

--- a/jira-stats-serverless/analyzer/domain/domain.go
+++ b/jira-stats-serverless/analyzer/domain/domain.go
@@ -21,6 +21,7 @@ type Ticket struct {
 	Id          string
 	Key         string
 	State       string
+	Type        string
 	Title       string
 	Transitions []TransitionInterval
 	UpdateTime  time.Time
@@ -130,6 +131,7 @@ func JiraToDomain(jiraIssue jira.Issue) (Ticket, error) {
 		Id:         jiraIssue.ID,
 		Key:        jiraIssue.Key,
 		Title:      jiraIssue.Fields.Summary,
+		Type:       jiraIssue.Fields.Type.Name,
 		State:      state,
 		UpdateTime: updateTime,
 		CreateTime: createdTime,

--- a/jira-stats-serverless/test/unit/dev_time_calc_test.go
+++ b/jira-stats-serverless/test/unit/dev_time_calc_test.go
@@ -149,3 +149,19 @@ func TestMultipleDevIntervals(t *testing.T) {
 	hours := domain.CalculateDevDays(ticket, startDate, endDate)
 	assert.Equal(t, 1.0+2.5, hours, "Incorrect number of dev hours calculated")
 }
+
+// Tests skipping calculations
+func TestSkippingTickets(t *testing.T) {
+	startDate := dirtyDate("2020-01-01T00:00:00")
+	endDate := dirtyDate("2020-03-31T23:59:59")
+
+	ticket := createTicket("In Review", dirtyDate("2020-02-01T09:00:00"))
+	ticket.Type = "Epic"
+	ticket.Transitions = domain.MakeIntervals(ticket,
+		createTransition("To Do", "In Development", dirtyDate("2020-02-02T09:00:00")),
+		createTransition("In Development", "In Review", dirtyDate("2020-02-03T19:00:00")),
+	)
+
+	hours := domain.CalculateDevDays(ticket, startDate, endDate)
+	assert.Equal(t, 0.0, hours, "Epic should not be taken into account")
+}


### PR DESCRIPTION
All tickets of type `Epic` have now dev interval always equal to 0.